### PR TITLE
Fix comparison

### DIFF
--- a/lazy_object.gemspec
+++ b/lazy_object.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec'
 end

--- a/lib/lazy_object.rb
+++ b/lib/lazy_object.rb
@@ -9,6 +9,7 @@
 # lazy = LazyObject.new { VeryExpensiveObject.new } # At this point the VeryExpensiveObject hasn't been initialized yet.
 # lazy.get_expensive_results(foo, bar) # Initializes VeryExpensiveObject and calls 'get_expensive_results' on it, passing in foo and bar
 class LazyObject < BasicObject
+  include ::Comparable
 
   def self.version
     '0.0.2'
@@ -16,6 +17,10 @@ class LazyObject < BasicObject
 
   def initialize(&callable)
     @__callable__ = callable
+  end
+
+  def <=>(item)
+    __target_object__ <=> item
   end
 
   # Cached target object.

--- a/lib/lazy_object.rb
+++ b/lib/lazy_object.rb
@@ -12,7 +12,7 @@ class LazyObject < BasicObject
   include ::Comparable
 
   def self.version
-    '0.0.2'
+    '0.0.3'
   end
 
   def initialize(&callable)

--- a/lib/lazy_object.rb
+++ b/lib/lazy_object.rb
@@ -9,8 +9,6 @@
 # lazy = LazyObject.new { VeryExpensiveObject.new } # At this point the VeryExpensiveObject hasn't been initialized yet.
 # lazy.get_expensive_results(foo, bar) # Initializes VeryExpensiveObject and calls 'get_expensive_results' on it, passing in foo and bar
 class LazyObject < BasicObject
-  include ::Comparable
-
   def self.version
     '0.0.3'
   end
@@ -19,8 +17,16 @@ class LazyObject < BasicObject
     @__callable__ = callable
   end
 
-  def <=>(item)
-    __target_object__ <=> item
+  def ==(item)
+    __target_object__ == item
+  end
+
+  def !=(item)
+    __target_object__ != item
+  end
+
+  def !
+    !__target_object__
   end
 
   # Cached target object.

--- a/spec/lazy_object_spec.rb
+++ b/spec/lazy_object_spec.rb
@@ -26,4 +26,8 @@ RSpec.describe LazyObject do
     expect( lazy_object.method_with_yield(:baz) { |foo| "--#{foo}--" } ).to eq('--baz--')
   end
 
+  it 'should return correct value when comparing' do
+    one = LazyObject.new { 1 }
+    expect(one).to eq(1)
+  end
 end


### PR DESCRIPTION
I run into this issue where comparing values wrapped in a `LazyObject` returns unexpected results

```ruby
one = LazyObject.new { 1 }
one == 1
# => false
``` 