### PR TITLE
Support for Ruby 3

### DIFF
--- a/lazy_object.gemspec
+++ b/lazy_object.gemspec
@@ -4,14 +4,15 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'lazy_object'
 
 Gem::Specification.new do |spec|
-  spec.name          = "lazy_object"
-  spec.version       = LazyObject.version
-  spec.authors       = ["Arthur Shagall", "Sergey Potapov"]
-  spec.email         = ["arthur.shagall@gmail.com"]
-  spec.summary       = %q{Lazily initialized object wrapper.}
-  spec.description   = %q{It's an object wrapper that forwards all calls to the reference object. This object is not created until the first method dispatch.}
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.name                   = "lazy_object"
+  spec.version                = LazyObject.version
+  spec.authors                = ["Arthur Shagall", "Sergey Potapov"]
+  spec.email                  = ["arthur.shagall@gmail.com"]
+  spec.summary                = %q{Lazily initialized object wrapper.}
+  spec.description            = %q{It's an object wrapper that forwards all calls to the reference object. This object is not created until the first method dispatch.}
+  spec.homepage               = ""
+  spec.license                = "MIT"
+  spec.required_ruby_version  = ">= 2.7.0"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/lazy_object.rb
+++ b/lib/lazy_object.rb
@@ -10,7 +10,7 @@
 # lazy.get_expensive_results(foo, bar) # Initializes VeryExpensiveObject and calls 'get_expensive_results' on it, passing in foo and bar
 class LazyObject < BasicObject
   def self.version
-    '0.0.4'
+    '0.1.0'
   end
 
   def initialize(&callable)

--- a/lib/lazy_object.rb
+++ b/lib/lazy_object.rb
@@ -10,7 +10,7 @@
 # lazy.get_expensive_results(foo, bar) # Initializes VeryExpensiveObject and calls 'get_expensive_results' on it, passing in foo and bar
 class LazyObject < BasicObject
   def self.version
-    '0.0.3'
+    '0.0.4'
   end
 
   def initialize(&callable)

--- a/lib/lazy_object.rb
+++ b/lib/lazy_object.rb
@@ -17,12 +17,12 @@ class LazyObject < BasicObject
     @__callable__ = callable
   end
 
-  def ==(item)
-    __target_object__ == item
+  def ==(other)
+    __target_object__ == other
   end
 
-  def !=(item)
-    __target_object__ != item
+  def !=(other)
+    __target_object__ != other
   end
 
   def !
@@ -35,7 +35,7 @@ class LazyObject < BasicObject
   end
 
   # Forwards all method calls to the target object.
-  def method_missing(method_name, *args, &block)
-    __target_object__.send(method_name, *args, &block)
+  def method_missing(method_name, ...)
+    __target_object__.send(method_name, ...)
   end
 end

--- a/spec/lazy_object_spec.rb
+++ b/spec/lazy_object_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe LazyObject do
     def method_with_yield(foo)
       yield foo
     end
+
+    def method_with_kwargs(**kwargs)
+      kwargs
+    end
   end
 
   let(:lazy_object) {
@@ -18,16 +22,28 @@ RSpec.describe LazyObject do
     end
   }
 
-  it 'should call the init block and forward methods to the target object' do
-    expect( lazy_object.value ).to eq(:foo)
+  it "should call the init block and forward methods to the target object" do
+    expect(lazy_object.value).to eq(:foo)
     lazy_object.value = :bar
-    expect( lazy_object.value ).to eq(:bar)
+    expect(lazy_object.value).to eq(:bar)
 
-    expect( lazy_object.method_with_yield(:baz) { |foo| "--#{foo}--" } ).to eq('--baz--')
+    expect(
+      lazy_object.method_with_yield(:baz) { |foo| "--#{foo}--" }
+    ).to eq("--baz--")
+  end
+
+  context "when target object methods use keyword arguments" do
+    subject(:target_method) { lazy_object.method_with_kwargs(foo: "bar") }
+    let(:lazy_object) { LazyObject.new { TargetObject.new } }
+
+    it "should not raise an exception and properly delegate to the target object" do
+      expect { target_method }.not_to raise_exception
+      expect(target_method).to eq({foo: "bar"})
+    end
   end
 
   context "equality operators" do
-    it 'should return correct value when comparing' do
+    it "should return correct value when comparing" do
       one = LazyObject.new { 1 }
       expect(one).to eq(1)
     end


### PR DESCRIPTION
Ruby 3 introduces separation between positional and keyword arguments which breaks how this library handles delegation. The fix is to use the argument forwarding shorthand (`...`) introduced in Ruby 2.7 to forward all the arguments regardless if they're positional, keyword, or a block.

This does mean that backwards compatibility with Ruby 2.6 and older is no longer supported. Given that [Ruby 2.6 will reach EOL on 2022-03-31](https://www.ruby-lang.org/en/downloads/branches/) I don't think that's an actual problem (people can still use the older version for Ruby 2.6 support if required).