### PR TITLE
Fix falsy value memoization

### DIFF
--- a/lib/lazy_object.rb
+++ b/lib/lazy_object.rb
@@ -31,7 +31,11 @@ class LazyObject < BasicObject
 
   # Cached target object.
   def __target_object__
-    @__target_object__ ||= @__callable__.call
+    if defined?(@__target_object__)
+      @__target_object__
+    else
+      @__target_object__ = @__callable__.call
+    end
   end
 
   # Forwards all method calls to the target object.

--- a/spec/lazy_object_spec.rb
+++ b/spec/lazy_object_spec.rb
@@ -71,6 +71,24 @@ RSpec.describe LazyObject do
     end
   end
 
+  context "when target object evaluates to a falsy value" do
+    let(:lazy_object) { LazyObject.new { TargetObject.new } }
+
+    it "evaluates the block exactly once for false" do
+      TargetObject.should_receive(:new).once.and_return(false)
+      3.times do
+        expect(lazy_object).to eq(false)
+      end
+    end
+
+    it "evaluates the block exactly once for nil" do
+      TargetObject.should_receive(:new).once.and_return(nil)
+      3.times do
+        expect(lazy_object).to eq(nil)
+      end
+    end
+  end
+
   context "equality operators" do
     it "should return correct value when comparing" do
       one = LazyObject.new { 1 }


### PR DESCRIPTION
This PR fixes a bug where the target block evaluates to a falsy value (`nil` or `false`). The current implementation uses an incorrect memoization technique (`||=`) which can only handle truthy values. This results in the block being re-evaluated multiple times:

```ruby
value = LazyObject.new { puts 'evaluting...'; false }
# evaluting...
# evaluting...
# evaluting...

value
# evaluting...
# evaluting...
# evaluting...
```