### PR TITLE
fix: def respond_to? and respond_to_missing?

### DIFF
--- a/lib/lazy_object.rb
+++ b/lib/lazy_object.rb
@@ -38,8 +38,14 @@ class LazyObject < BasicObject
     end
   end
 
+  def respond_to_missing?(method_name, include_private = false)
+    __target_object__.respond_to?(method_name, include_private)
+  end
+
+  alias respond_to? respond_to_missing?
+
   # Forwards all method calls to the target object.
   def method_missing(method_name, ...)
-    __target_object__.send(method_name, ...)
+	__target_object__.public_send(method_name, ...)
   end
 end

--- a/spec/lazy_object_spec.rb
+++ b/spec/lazy_object_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe LazyObject do
     def method_with_kwargs_and_yield(**kwargs)
       yield **kwargs
     end
+
+  private
+
+  	def private_method_one_pos_arg(foo)
+		foo
+	end
   end
 
   let(:lazy_object) {
@@ -86,6 +92,35 @@ RSpec.describe LazyObject do
       3.times do
         expect(lazy_object).to eq(nil)
       end
+    end
+  end
+
+  context "respond_to?" do
+    let(:lazy_object) { LazyObject.new { TargetObject.new } }
+
+    it "responds to methods defined on the target object" do
+      expect(lazy_object.respond_to?(:value)).to eq(true)
+      expect(lazy_object.respond_to?(:method_with_yield)).to eq(true)
+    end
+
+    it "does not respond to methods not defined on the target object" do
+      expect(lazy_object.respond_to?(:nonexistent_method)).to eq(false)
+    end
+
+    it "does not respond to private methods by default" do
+      expect(lazy_object.respond_to?(:private_method_one_pos_arg)).to eq(false)
+    end
+
+    it "responds to private methods when include_private is true" do
+      expect(lazy_object.respond_to?(:private_method_one_pos_arg, true)).to eq(true)
+    end
+  end
+
+  context "private methods on the target object" do
+    let(:lazy_object) { LazyObject.new { TargetObject.new } }
+
+    it "raises NoMethodError when calling a private method" do
+      expect { lazy_object.private_method_one_pos_arg(:bar) }.to raise_error(::NoMethodError)
     end
   end
 


### PR DESCRIPTION
both needed since BasicObject doesn't get `respond_to?`

I encountered his bug:
```
"/home/phillipdavis/everyday/dev/mboa/sgx-bwmsgsv2/.gems/ruby/3.4.0/gems/lazy_object-0.2.0/lib/lazy_object.rb:44:in 'Kernel#exec'",                                                     
   "/home/phillipdavis/everyday/dev/mboa/sgx-bwmsgsv2/.gems/ruby/3.4.0/gems/lazy_object-0.2.0/lib/lazy_object.rb:44:in 'LazyObject#method_missing'",                                       
   "/home/phillipdavis/everyday/dev/mboa/sgx-bwmsgsv2/lib/registration_repo.rb:46:in 'block in RegistrationRepo#put'"
```
while trying to use [em-hiredis](https://github.com/mloughran/em-hiredis) to run `REDIS.exec` (the command to close a transaction). Since this command is transmitted to the server using a `method_missing` implementation, LazyObject's own `method_missing` implementation erroneously executed `Kernel.exec`.

I think this fix is fine since the public API of the LazyObject should be the same as that of the object that it wraps.